### PR TITLE
Program was crashing when the domain was down.

### DIFF
--- a/Kohl.Framework/Framework.Info/UserInfo.cs
+++ b/Kohl.Framework/Framework.Info/UserInfo.cs
@@ -36,7 +36,15 @@ namespace Kohl.Framework.Info
                 else if (!MachineInfo.IsUnix && !string.IsNullOrWhiteSpace(UserNameAlias))
                 {
 					DirectoryEntry userEntry = new DirectoryEntry("WinNT://" + UserDomain + "/" + UserNameAlias + ",User");
-					return (string)userEntry.Properties["fullname"].Value;
+
+                    try
+                    {
+                        return (string)userEntry.Properties["fullname"].Value;
+                    }
+                    catch (System.Runtime.InteropServices.COMException)
+                    {
+                        return null;
+                    }
 
 					/*
 					 * System.DirectoryServices.AccountManagement is not defined in Mono


### PR DESCRIPTION
Yesterday I was having problems with my domain, and whenever I opened Terminals it would crash.
The Exception details are below...

> Application: Terminals.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.Runtime.InteropServices.COMException
   at System.DirectoryServices.DirectoryEntry.Bind(Boolean)
   at System.DirectoryServices.DirectoryEntry.Bind()
   at System.DirectoryServices.DirectoryEntry.get_AdsObject()
   at System.DirectoryServices.PropertyValueCollection.PopulateList()
   at System.DirectoryServices.PropertyValueCollection..ctor(System.DirectoryServices.DirectoryEntry, System.String)
   at System.DirectoryServices.PropertyCollection.get_Item(System.String)
   at Kohl.Framework.Info.UserInfo.get_UserName()
   at Kohl.Framework.Info.HumanReadableInfo.ToString()
   at Kohl.Framework.Info.HumanReadableInfo.ToLog()
   at Terminals.Program+<>c.<LogGeneralProperties>b__29_0()
   at System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
   at System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object, Boolean)
   at System.Threading.ExecutionContext.Run(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
   at System.Threading.ThreadHelper.ThreadStart()
